### PR TITLE
Disable pinch-zoom and input focus-zoom for native PWA feel

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -189,6 +189,16 @@
   }
   html {
     @apply font-sans scroll-smooth;
+    /* Native-app feel: kill double-tap-to-zoom (the viewport meta blocks
+       pinch-zoom; this covers the double-tap gesture). */
+    touch-action: manipulation;
+  }
+  /* iOS zooms toward any focused control whose text is under 16px. Keeping the
+     font at least 16px stops that jump even where the viewport hint is loose. */
+  input,
+  textarea,
+  select {
+    font-size: max(16px, 1rem);
   }
   /* Honour reduced-motion — no smooth-scroll animation for anchor jumps. */
   @media (prefers-reduced-motion: reduce) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,11 @@ export const viewport: Viewport = {
     { media: '(prefers-color-scheme: light)', color: '#ffffff' },
     { media: '(prefers-color-scheme: dark)', color: '#0a0a0b' },
   ],
+  // Native-app feel: no pinch-zoom, and no auto-zoom when focusing an input.
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
 }
 
 export default function RootLayout({


### PR DESCRIPTION
Lock the viewport (maximum-scale=1, user-scalable=no) so the standalone
PWA no longer pinch-zooms or jumps toward a focused input. Belt-and-
suspenders in CSS: touch-action: manipulation kills double-tap zoom, and
a 16px floor on inputs stops iOS focus-zoom where the viewport hint is
loose.