### PR TITLE
Add nickname chips: award a chip for winning with a folk-named hand

### DIFF
--- a/docs/awards.md
+++ b/docs/awards.md
@@ -34,7 +34,7 @@ Unearned chips show as hollow outlines (the hatch pattern used for face-down car
 so the shelf reads as a collection with visible gaps — the pull is seeing what's
 missing, not a nag.
 
-## The set (30 chips)
+## The set (55 chips)
 
 ### Venue chips — one per rung, earned by **winning** the venue (10)
 
@@ -72,6 +72,20 @@ chip certifies a real moment, not a folded-out technicality.
 | `moment-comeback` | "The Comeback" | Win a ladder venue after falling to ≤10% of your starting stack |
 | `moment-chipandchair` | "Chip and a Chair" | Win a ladder venue after being ground down to ≤1 big blind |
 
+### Nickname chips — win a pot holding a folk-named starting hand (25)
+
+| id | Chip | Earned by |
+|----|------|-----------|
+| `nickname-KK` … `nickname-93` | The hand's folk name (jade) | Win a pot holding that named starting hand |
+
+Generated one-to-one from the nicknames in `src/config/handNames.ts` (Cowboys,
+Ladies, Snowmen, Motown, The Heinz …), so the shelf tracks that list exactly.
+The three most iconic named hands — pocket aces, Ace-King, 7-2 — are **not**
+duplicated here; they keep their bespoke moment chips (The Bullets, Big Slick,
+The Seven Deuce). Detection reuses `nicknameKeyFor` from `handNames`, so the
+whisper you see when dealt the hand and the chip you earn for winning with it
+are always the same set.
+
 ### Journey chips — the story of the grind (6)
 
 | id | Chip | Earned by |
@@ -89,8 +103,8 @@ minutes.
 All triggers are observable at two seams — no engine changes:
 
 - **`finishHand()`** in `store/game.ts` already knows: winners, `result.evaluations`
-  (hand names), payouts, survivors, and the venue → hand chips + venue chips + rank
-  chips (from the just-updated `peakRoll`).
+  (hand names), payouts, survivors, hero's hole cards, and the venue → hand chips +
+  venue chips + nickname chips + rank chips (from the just-updated `peakRoll`).
 - "Back From Broke" uses one persisted flag (`cameFromFreeroll`): set on a Kitchen
   Table win, consumed when the comeback chip is earned, and cleared if you bust back
   below the Garage buy-in first.

--- a/src/components/profile/ChipsDialog.tsx
+++ b/src/components/profile/ChipsDialog.tsx
@@ -25,6 +25,7 @@ const SECTIONS: { kind: AwardKind; title: string }[] = [
   { kind: 'venue', title: 'Venues' },
   { kind: 'hand', title: 'Hands' },
   { kind: 'moment', title: 'Moments' },
+  { kind: 'nickname', title: 'Nicknames' },
   { kind: 'journey', title: 'The Journey' },
 ]
 

--- a/src/config/handNames.ts
+++ b/src/config/handNames.ts
@@ -6,8 +6,9 @@ import { RANKS, type Card } from '@/lib/poker/cards'
 
 // Keys: rank pair high-first (`AA`), optionally suffixed `s`/`o` when the
 // nickname belongs to only one variant (The Hammer is 7-2 *offsuit*). Bare
-// keys apply to suited and offsuit alike.
-const NICKNAMES: Record<string, string> = {
+// keys apply to suited and offsuit alike. Non-pair keys are high rank first to
+// match `holeKey` — otherwise they never resolve.
+export const NICKNAMES: Record<string, string> = {
   AA: 'Pocket Rockets',
   KK: 'Cowboys',
   QQ: 'Ladies',
@@ -34,8 +35,8 @@ const NICKNAMES: Record<string, string> = {
   T4: 'Ten-Four',
   '95': 'Dolly Parton',
   '72o': 'The Hammer',
-  '57': 'The Heinz',
-  '39': 'Jack Benny',
+  '75': 'The Heinz',
+  '93': 'Jack Benny',
 }
 
 /** Canonical starting-hand key: high rank first, `s`/`o` for non-pairs. */
@@ -46,9 +47,21 @@ export function holeKey(cards: readonly Card[]): string | null {
   return `${a.rank}${b.rank}${a.suit === b.suit ? 's' : 'o'}`
 }
 
-/** The folk name for these hole cards, or null — most hands have none. */
-export function nicknameFor(cards: readonly Card[]): string | null {
+/**
+ * The canonical `NICKNAMES` key these hole cards resolve to, or null. Prefers
+ * the exact key (`72o`) and falls back to the bare rank pair (`72`), so a
+ * suited-only nickname never leaks onto the offsuit hand and vice versa.
+ */
+export function nicknameKeyFor(cards: readonly Card[]): string | null {
   const key = holeKey(cards)
   if (!key) return null
-  return NICKNAMES[key] ?? NICKNAMES[key.slice(0, 2)] ?? null
+  if (NICKNAMES[key]) return key
+  const bare = key.slice(0, 2)
+  return NICKNAMES[bare] ? bare : null
+}
+
+/** The folk name for these hole cards, or null — most hands have none. */
+export function nicknameFor(cards: readonly Card[]): string | null {
+  const key = nicknameKeyFor(cards)
+  return key ? NICKNAMES[key] : null
 }

--- a/src/lib/awards.ts
+++ b/src/lib/awards.ts
@@ -5,9 +5,10 @@
 
 import { VENUES, type Venue } from '@/config/venues'
 import { RANKS } from '@/config/ranks'
+import { NICKNAMES, nicknameKeyFor } from '@/config/handNames'
 import type { Card } from '@/lib/poker/cards'
 
-export type AwardKind = 'venue' | 'hand' | 'moment' | 'journey'
+export type AwardKind = 'venue' | 'hand' | 'moment' | 'nickname' | 'journey'
 
 export interface AwardDef {
   id: string
@@ -25,6 +26,7 @@ const PIP = '#7c8cf0'
 const SUIT_RED = '#f0574e'
 const GOLD = '#e8b923'
 const AMBER = '#e0a458'
+const JADE = '#3fa78e'
 
 /** Venue chips — earned by *winning* the venue, not entering it. */
 const venueChips: AwardDef[] = VENUES.map((v, i) => ({
@@ -156,6 +158,63 @@ const momentChips: AwardDef[] = [
   },
 ]
 
+// The three most iconic named hands keep their bespoke moment chips (The
+// Bullets, Big Slick, The Seven Deuce) — they're not duplicated here.
+const NICKNAME_MOMENTS = new Set(['AA', 'AK', '72o'])
+
+const RANK_WORD: Record<string, string> = {
+  A: 'Ace',
+  K: 'King',
+  Q: 'Queen',
+  J: 'Jack',
+  T: 'Ten',
+  '9': 'Nine',
+  '8': 'Eight',
+  '7': 'Seven',
+  '6': 'Six',
+  '5': 'Five',
+  '4': 'Four',
+  '3': 'Three',
+  '2': 'Deuce',
+}
+const PLURAL: Record<string, string> = {
+  Ace: 'aces',
+  King: 'kings',
+  Queen: 'queens',
+  Jack: 'jacks',
+  Ten: 'tens',
+  Nine: 'nines',
+  Eight: 'eights',
+  Seven: 'sevens',
+  Six: 'sixes',
+  Five: 'fives',
+  Four: 'fours',
+  Three: 'threes',
+  Deuce: 'deuces',
+}
+
+/** "pocket queens" / "Ace-Jack" — reads the two rank chars of a nickname key. */
+const describeHole = (key: string): string => {
+  const [a, b] = [RANK_WORD[key[0]], RANK_WORD[key[1]]]
+  return a === b ? `pocket ${PLURAL[a]}` : `${a}-${b}`
+}
+
+/**
+ * Nickname chips — win a pot holding one of poker's folk-named starting hands
+ * (`config/handNames.ts`). Generated so the shelf tracks that list one-to-one,
+ * minus the three hands that already have their own moment chip.
+ */
+const nicknameChips: AwardDef[] = Object.entries(NICKNAMES)
+  .filter(([key]) => !NICKNAME_MOMENTS.has(key))
+  .map(([key, name]) => ({
+    id: `nickname-${key}`,
+    kind: 'nickname',
+    name,
+    how: `Win a pot holding ${describeHole(key)}`,
+    color: JADE,
+    glyph: key.slice(0, 2),
+  }))
+
 const rankMin = (name: string) => RANKS.find((r) => r.name === name)!.min
 
 /** Journey chips — the story of the grind. */
@@ -214,6 +273,7 @@ export const AWARDS: readonly AwardDef[] = [
   ...venueChips,
   ...handChips,
   ...momentChips,
+  ...nicknameChips,
   ...journeyChips,
 ]
 
@@ -294,6 +354,13 @@ export function detectAwards(ctx: AwardContext, owned: Record<string, number>): 
   if (ctx.tournamentWon && ctx.venue.freeroll !== true) {
     if (ctx.lowestStack <= ctx.startingStack / 10) add('moment-comeback')
     if (ctx.lowestStack <= ctx.bigBlind) add('moment-chipandchair')
+  }
+
+  // Nickname chips — any won pot holding a folk-named starting hand. The three
+  // hands with bespoke moment chips have no `nickname-*` def, so `add` no-ops.
+  if (ctx.heroWon && ctx.heroHole) {
+    const key = nicknameKeyFor(ctx.heroHole)
+    if (key) add(`nickname-${key}`)
   }
 
   // Venue + comeback chips fire on taking the table down (ladder venues only).

--- a/tests/awards.test.ts
+++ b/tests/awards.test.ts
@@ -26,14 +26,16 @@ const ids = (ctx: AwardContext, owned: Record<string, number> = {}) =>
 const showdownWin = (name: string, description: string, over: Partial<AwardContext> = {}) =>
   baseCtx({ heroWon: true, showdown: true, heroHand: { name, description }, ...over })
 
-test('the set has 30 chips with unique ids', (t) => {
-  t.is(AWARDS.length, 30)
-  t.is(new Set(AWARDS.map((a) => a.id)).size, 30)
+test('the set has 55 chips with unique ids', (t) => {
+  t.is(AWARDS.length, 55)
+  t.is(new Set(AWARDS.map((a) => a.id)).size, 55)
   t.is(AWARDS.filter((a) => a.kind === 'venue').length, 10)
   t.is(AWARDS.filter((a) => a.kind === 'hand').length, 7)
   t.is(AWARDS.filter((a) => a.kind === 'moment').length, 7)
+  t.is(AWARDS.filter((a) => a.kind === 'nickname').length, 25)
   t.is(AWARDS.filter((a) => a.kind === 'journey').length, 6)
   t.truthy(awardById('venue-garage'))
+  t.truthy(awardById('nickname-QQ'))
 })
 
 test('winning a ladder venue earns its chip — once', (t) => {
@@ -109,10 +111,31 @@ test('The Seven Deuce needs a won pot holding exactly 7-2', (t) => {
     baseCtx({ heroWon: true, heroHole: [cardFromString(a), cardFromString(b)] })
   t.deepEqual(ids(holding('7c', '2d')), ['moment-sevendeuce', 'journey-first'])
   t.deepEqual(ids(holding('2s', '7h')), ['moment-sevendeuce', 'journey-first'])
-  t.deepEqual(ids(holding('7c', '7d')), ['journey-first'])
+  // pocket sevens aren't 7-2 — but they are Hockey Sticks, a named hand
+  t.deepEqual(ids(holding('7c', '7d')), ['nickname-77', 'journey-first'])
   t.deepEqual(ids(holding('Ac', '2d')), ['journey-first'])
   // losing with 7-2 earns nothing
   t.deepEqual(ids(baseCtx({ heroHole: [cardFromString('7c'), cardFromString('2d')] })), [])
+})
+
+test('nickname chips fire on a won pot with a folk-named starting hand', (t) => {
+  const holding = (a: string, b: string) =>
+    baseCtx({ heroWon: true, heroHole: [cardFromString(a), cardFromString(b)] })
+  // pairs and offsuit/suited-agnostic names
+  t.deepEqual(ids(holding('Qc', 'Qd')), ['nickname-QQ', 'journey-first']) // Ladies
+  t.deepEqual(ids(holding('5c', 'Jh')), ['nickname-J5', 'journey-first']) // Motown, any order
+  // The Heinz (5-7) and Jack Benny (3-9) resolve to their high-first keys
+  t.deepEqual(ids(holding('7c', '5d')), ['nickname-75', 'journey-first'])
+  t.deepEqual(ids(holding('9c', '3d')), ['nickname-93', 'journey-first'])
+  // an unnamed hand earns no nickname chip
+  t.deepEqual(ids(holding('9c', '4d')), ['journey-first'])
+  // losing with a named hand earns nothing
+  t.deepEqual(ids(baseCtx({ heroHole: [cardFromString('Qc'), cardFromString('Qd')] })), [])
+  // the three iconic hands keep their bespoke moment chip — no nickname duplicate
+  t.deepEqual(ids(holding('Ac', 'Ad')), ['moment-bullets', 'journey-first'])
+  t.deepEqual(ids(holding('7c', '2d')), ['moment-sevendeuce', 'journey-first'])
+  t.is(awardById('nickname-AA'), undefined)
+  t.is(awardById('nickname-AK'), undefined)
 })
 
 test('The Bouncer fires on a clean knockout', (t) => {

--- a/tests/handNames.test.ts
+++ b/tests/handNames.test.ts
@@ -18,6 +18,9 @@ test('named hands resolve regardless of order or suits', (t) => {
   t.is(nicknameFor(hole('Ac', 'Ad')), 'Pocket Rockets')
   t.is(nicknameFor(hole('5c', 'Jh')), 'Motown')
   t.is(nicknameFor(hole('7d', 'Qs')), 'The Computer Hand')
+  // non-pair names whose ranks read low-first still resolve (keys are high-first)
+  t.is(nicknameFor(hole('5c', '7h')), 'The Heinz')
+  t.is(nicknameFor(hole('3d', '9s')), 'Jack Benny')
 })
 
 test('suffixed names apply to only that variant', (t) => {


### PR DESCRIPTION
Extends the awards ("special chips") set with a Nicknames group — win a
pot holding one of poker's folk-named starting hands (Cowboys, Ladies,
Snowmen, Motown, The Heinz …) and you collect that hand's chip.

- Generate the chips one-to-one from NICKNAMES in config/handNames.ts, so
  the shelf tracks that list exactly. The three most iconic hands (AA, AK,
  7-2) keep their existing bespoke moment chips and aren't duplicated.
- Detection reuses the same resolver as the dealt-hand whisper via a new
  nicknameKeyFor helper, so the name you're whispered and the chip you earn
  are always the same set.
- Fix two nickname keys that could never match holeKey's high-first output:
  The Heinz (57 -> 75) and Jack Benny (39 -> 93). This also repairs their
  ambient whispers, which never showed before.
- New 'nickname' award kind + Nicknames shelf section; docs and tests updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016PgYbGcWgiJJEZBik8mrTs