### PR TITLE
Move table help & history icons above the community cards

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -24,8 +24,8 @@ type Leading = 'profile' | 'back' | 'none'
  * - `leading='back'` — every sub-screen: a chevron back (to the menu by
  *   default, or `onBack` for a custom exit like the table's leave-confirm).
  * - `title` — an optional centred label (the table shows venue + blinds).
- * - `actions` — page-specific buttons (e.g. the table's History / Help),
- *   rendered just before the shared pip · Style · Settings cluster.
+ * - `actions` — page-specific buttons, rendered just before the shared
+ *   pip · Style · Settings cluster.
  */
 export function AppBar({
   leading = 'back',

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -143,6 +143,33 @@ export function Table() {
     </div>
   )
 
+  // History + Help live here now — a small cluster pinned to the top-left of the
+  // table surface, above the community cards, rather than crowding the AppBar.
+  const boardControls = (
+    <div className="absolute left-4 top-2 z-20 flex items-center gap-0.5 md:left-6">
+      {hasHistory && (
+        <AppBarAction
+          label="Last hand"
+          onClick={() => {
+            sound.play('tap')
+            setHistoryOpen(true)
+          }}
+        >
+          <History className="size-4" />
+        </AppBarAction>
+      )}
+      <AppBarAction
+        label="Hand rankings"
+        onClick={() => {
+          sound.play('tap')
+          setHelpOpen(true)
+        }}
+      >
+        <HelpCircle className="size-4" />
+      </AppBarAction>
+    </div>
+  )
+
   const actionArea =
     status === 'handover' ? (
       // Entrance transform lives on the wrapper; the button keeps its own CSS
@@ -212,30 +239,6 @@ export function Table() {
             </span>
           </>
         }
-        actions={
-          <>
-            {hasHistory && (
-              <AppBarAction
-                label="Last hand"
-                onClick={() => {
-                  sound.play('tap')
-                  setHistoryOpen(true)
-                }}
-              >
-                <History className="size-4" />
-              </AppBarAction>
-            )}
-            <AppBarAction
-              label="Hand rankings"
-              onClick={() => {
-                sound.play('tap')
-                setHelpOpen(true)
-              }}
-            >
-              <HelpCircle className="size-4" />
-            </AppBarAction>
-          </>
-        }
       />
 
       {isMobile ? (
@@ -244,6 +247,7 @@ export function Table() {
           {/* opponents + board drift toward the centre — slack splits evenly
               above, between, and below them */}
           <div className="relative flex min-h-0 flex-1 flex-col justify-evenly px-2 pb-2">
+            {boardControls}
             <div className="flex items-start justify-evenly">
               {opponents.map((p) => {
                 const meta = metaById.get(p.id)
@@ -320,6 +324,7 @@ export function Table() {
         <>
           {/* table surface + seats */}
           <div className="relative flex-1">
+            {boardControls}
             {opponents.map((p, i) => {
               const meta = metaById.get(p.id)
               if (!meta) return null


### PR DESCRIPTION
Relocate the History and Hand-rankings buttons out of the AppBar and
into a small cluster pinned to the top-left of the table surface, above
the community cards, so the navbar is less crowded.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DyZfDKNuR24tDn48MKQLRe