### PR TITLE
test: cover formatChips() in useMoney

### DIFF
--- a/tests/useMoney.test.ts
+++ b/tests/useMoney.test.ts
@@ -1,0 +1,59 @@
+import test from 'ava'
+import { formatChips, useMoney } from '@/lib/useMoney'
+
+// formatChips is `Math.round(amount).toLocaleString()`. Called with no locale
+// argument, toLocaleString() uses Node's default locale — which resolves to
+// en-US in every environment this runs in. CI is Node 22 on ubuntu-latest
+// (LANG=C.UTF-8), and Node's bundled ICU falls back to en-US for C / C.UTF-8 /
+// an unset locale alike, all of which yield the comma-grouped, '.'-decimal
+// output asserted below. So these exact strings are deterministic despite
+// toLocaleString() being locale-dependent in general.
+//
+// Real call sites (pot wins in src/store/game.ts, chip balances in components)
+// pass non-negative integers, but formatChips is a pure, total function over
+// all numbers, so the rounding / negative / edge cases below document its
+// actual behaviour rather than only the values seen in the app today.
+
+test('small non-negative integers are returned as-is', (t) => {
+  t.is(formatChips(0), '0')
+  t.is(formatChips(7), '7')
+  t.is(formatChips(999), '999')
+})
+
+test('thousands and above get a grouping separator', (t) => {
+  t.is(formatChips(1000), '1,000')
+  t.is(formatChips(1200), '1,200')
+  t.is(formatChips(12345), '12,345')
+  t.is(formatChips(1000000), '1,000,000')
+})
+
+test('non-integers are rounded to the nearest chip', (t) => {
+  t.is(formatChips(1.4), '1')
+  t.is(formatChips(1.6), '2')
+  t.is(formatChips(1234.49), '1,234')
+  t.is(formatChips(1234.5), '1,235')
+})
+
+test('halves round toward +Infinity, following Math.round', (t) => {
+  t.is(formatChips(0.5), '1')
+  t.is(formatChips(1.5), '2')
+  t.is(formatChips(2.5), '3')
+})
+
+test('negative amounts keep the sign and are still grouped', (t) => {
+  t.is(formatChips(-7), '-7')
+  t.is(formatChips(-1200), '-1,200')
+  t.is(formatChips(-1234567), '-1,234,567')
+})
+
+test('negative halves round toward +Infinity; -0.5 lands on -0', (t) => {
+  t.is(formatChips(-1.5), '-1')
+  t.is(formatChips(-2.5), '-2')
+  // Math.round(-0.5) === -0, and (-0).toLocaleString() keeps the sign.
+  t.is(formatChips(-0.5), '-0')
+})
+
+test('useMoney returns the same formatter function', (t) => {
+  t.is(useMoney(), formatChips)
+  t.is(useMoney()(1200), '1,200')
+})


### PR DESCRIPTION
Closes #16

Adds `tests/useMoney.test.ts` — 7 AVA tests asserting `formatChips()`'s actual behavior, read from the source per the issue: small integers pass through, thousands grouping (`1,200`, `1,000,000`), non-integers round to the nearest chip with `Math.round`'s toward-+Infinity halves (`0.5`→`1`, `1234.5`→`1,235`), negatives keep sign and grouping, and the honest `-0` quirk (`formatChips(-0.5)`→`"-0"` — documented in a comment; real call sites only pass non-negative integers, so the test documents the pure function's total behavior). Also asserts `useMoney()` returns the same function reference.

On locale determinism (the exact-string risk with a bare `toLocaleString()`): checked empirically that Node's bundled-ICU default resolves to `en-US` under `LANG=C`, `C.UTF-8` (the Actions ubuntu default), and unset locale alike — the no-separator `en-US-POSIX` behavior only appears when passed explicitly, which never happens here. Reasoning captured in the test file header, assertions kept in the repo's plain hardcoded-string style.

Local gates: format/types/lint/knip/audit all pass; the new tests are green (the pre-existing Monte-Carlo `ai.test.ts` suite times out on my overloaded box in full runs — isolated-run-reproducible and independent of this change, AVA per-file workers; your CI is the authoritative run there).

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)