### PR TITLE
Add an RSS 2.0 feed for the blog at /rss.xml

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,8 @@ const UMAMI_SRC = process.env.NEXT_PUBLIC_UMAMI_SRC ?? 'https://cloud.umami.is/s
 export const metadata: Metadata = {
   // Required so static-export OG/Twitter image URLs resolve to absolute links.
   metadataBase: new URL('https://playpip.io'),
+  // Feed discovery for readers — emitted as a <link rel="alternate"> on every page.
+  alternates: { types: { 'application/rss+xml': 'https://playpip.io/rss.xml' } },
   title: 'Pip — clean poker',
   description: "Casual Texas Hold'em, redesigned. No fake felt, no neon.",
   appleWebApp: {

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,0 +1,12 @@
+import { BLOG_POSTS, buildRssXml } from '@/config/blog'
+
+// Generated at build time into out/rss.xml (the app is a static export).
+
+// Required for the static export — rendered once at build into out/rss.xml.
+export const dynamic = 'force-static'
+
+export function GET(): Response {
+  return new Response(buildRssXml(BLOG_POSTS), {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  })
+}

--- a/src/config/blog.ts
+++ b/src/config/blog.ts
@@ -57,3 +57,49 @@ export function formatPostDate(date: string): string {
   const [y, m, d] = date.split('-').map(Number)
   return `${d} ${MONTHS[m - 1]} ${y}`
 }
+
+const SITE = 'https://playpip.io'
+
+/** Escape the five XML entities so registry copy stays safe to edit. */
+function escapeXml(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+/**
+ * RSS 2.0 feed for the blog, built from the registry as-is (newest first —
+ * the order tests/blog.test.ts pins), served statically from /rss.xml.
+ */
+export function buildRssXml(posts: BlogPost[]): string {
+  const items = posts
+    .map((post) => {
+      const url = `${SITE}/blog/${post.slug}`
+      const pubDate = new Date(`${post.date}T00:00:00Z`).toUTCString()
+      return [
+        '    <item>',
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${url}</link>`,
+        `      <guid>${url}</guid>`,
+        `      <description>${escapeXml(post.description)}</description>`,
+        `      <pubDate>${pubDate}</pubDate>`,
+        '    </item>',
+      ].join('\n')
+    })
+    .join('\n')
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0">',
+    '  <channel>',
+    '    <title>Blog · Pip</title>',
+    `    <link>${SITE}/blog</link>`,
+    '    <description>Notes from the Pip table — what shipped, what changed, and the occasional hand worth talking about.</description>',
+    items,
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n')
+}

--- a/tests/rss.test.ts
+++ b/tests/rss.test.ts
@@ -1,0 +1,57 @@
+import test from 'ava'
+import { BLOG_POSTS, buildRssXml } from '@/config/blog'
+
+test('the feed is RSS 2.0 with a single channel and the blog metadata', (t) => {
+  const xml = buildRssXml(BLOG_POSTS)
+  t.true(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0">'))
+  t.true(xml.endsWith('</channel>\n</rss>\n'))
+  t.is(xml.match(/<channel>/g)?.length, 1)
+  t.true(xml.includes('<title>Blog · Pip</title>'))
+  t.true(xml.includes('<link>https://playpip.io/blog</link>'))
+  t.true(
+    xml.includes(
+      '<description>Notes from the Pip table — what shipped, what changed, and the occasional hand worth talking about.</description>',
+    ),
+  )
+})
+
+test('one item per registry post, in registry order, with absolute URLs', (t) => {
+  const xml = buildRssXml(BLOG_POSTS)
+  const items = xml.match(/<item>[\s\S]*?<\/item>/g) ?? []
+  t.is(items.length, BLOG_POSTS.length)
+  items.forEach((item, i) => {
+    const post = BLOG_POSTS[i]
+    const url = `https://playpip.io/blog/${post.slug}`
+    t.true(item.includes(`<title>${post.title}</title>`), `title: ${post.slug}`)
+    t.true(item.includes(`<link>${url}</link>`), `link: ${post.slug}`)
+    t.true(item.includes(`<guid>${url}</guid>`), `guid: ${post.slug}`)
+    t.true(item.includes(`<description>${post.description}</description>`), `desc: ${post.slug}`)
+  })
+})
+
+test('pubDate is RFC-822 GMT, pinned to literals', (t) => {
+  const post = (date: string) => ({ slug: 'x', title: 't', description: 'd', date })
+  t.true(
+    buildRssXml([post('2026-07-25')]).includes('<pubDate>Sat, 25 Jul 2026 00:00:00 GMT</pubDate>'),
+  )
+  t.true(
+    buildRssXml([post('2026-07-26')]).includes('<pubDate>Sun, 26 Jul 2026 00:00:00 GMT</pubDate>'),
+  )
+  t.true(
+    buildRssXml([post('2027-01-01')]).includes('<pubDate>Fri, 01 Jan 2027 00:00:00 GMT</pubDate>'),
+  )
+})
+
+test('XML entities in titles and descriptions are escaped', (t) => {
+  const xml = buildRssXml([
+    {
+      slug: 'x',
+      title: 'A & B <C> "D" \'E\'',
+      description: 'fish & chips <tag>',
+      date: '2026-07-25',
+    },
+  ])
+  t.true(xml.includes('<title>A &amp; B &lt;C&gt; &quot;D&quot; &apos;E&apos;</title>'))
+  t.true(xml.includes('<description>fish &amp; chips &lt;tag&gt;</description>'))
+  t.false(xml.includes('A & B'))
+})


### PR DESCRIPTION
## Summary

Adds a build-time RSS 2.0 feed at `/rss.xml` for the blog, following `sitemap.ts` as the pattern you named, plus a discovery `<link>` in root metadata so readers can find it from any page.

## Related Issues and Pull Requests

Closes #21

## Changes

- `src/config/blog.ts` — adds `escapeXml` and a pure `buildRssXml(posts)` helper, alongside `formatPostDate` in the same module. It maps `BLOG_POSTS` in registry order without re-sorting, mirroring `sitemap.ts:21`, so the feed cannot drift from the blog index.
- `src/app/rss.xml/route.ts` — new route handler with `export const dynamic = 'force-static'`, matching how the static export already emits root-level `sitemap.xml` and `llms.txt`. The builder lives in `blog.ts` rather than here because Next's route-module rules forbid exporting a non-route symbol from `route.ts`.
- `src/app/layout.tsx` — `alternates.types` entry in the existing site-wide metadata object, so the discovery link lands on every page.
- `tests/rss.test.ts` — 4 AVA tests over the builder.

## Testing

Each gate run separately rather than as one aggregate:

| gate | result |
|---|---|
| `pnpm test:format` (biome check) | exit 0, 163 files |
| `pnpm test:types` (`tsc --noEmit`) | exit 0 |
| `pnpm test:lint` (`biome lint .`) | exit 0 |
| `pnpm test:ava` | exit 0, 138 tests |
| `pnpm test:knip` | exit 0 |
| `pnpm test:audit` | exit 0 |
| `pnpm build` | exit 0, 48 static pages including `/rss.xml` |

`pnpm build` emits `out/rss.xml` (1603 bytes). Parsed with a real XML parser: root `<rss version="2.0">`, one `<channel>` with `title`/`link`/`description`, three `<item>`s matching the three registry posts newest-first, each with `title`/`link`/`guid`/`description`/`pubDate`, all links and guids absolute, and every `pubDate` accepted by an RFC-822 parser. The W3C Feed Validator returned "Congratulations! This is a valid RSS feed." — though it was intermittently down while this was being built, so the local parse is what the tests actually rely on.

The tests were checked for bite by mutation, not just by reverting: neutering `escapeXml`'s `&` rule produces a real assertion failure (`Value is not 'true': false`, `tests/rss.test.ts:54`). Reverting the production files alone only produces an import error, which proves coupling rather than that the assertions bite — so I did both.

The discovery link was verified in the built output, not just in the source: all 40 emitted HTML files carry `<link rel="alternate" type="application/rss+xml" …>`.

## Follow-ups / Known Limitations

- **The tests pin the builder, not the emitted artifact.** All four call `buildRssXml()` directly; nothing asserts on `out/rss.xml`, the route's `force-static`, or the discovery `<link>`. A regression in any of those three would ship green. I verified all three by hand on this branch, but if you'd like them pinned I'm happy to add a build-output test.
- **The escaping path is covered only by synthetic test data.** No current post title or description contains `&`, `<`, `>`, `"` or `'` — the only non-ASCII characters in the real content are curly apostrophes and em-dashes, which are valid raw UTF-8. So the escaping is mutation-tested but not exercised by anything you've actually published yet.
- `pnpm test:audit` **passes** rather than being clean — it reports 2 moderate vulnerabilities that sit below the `--audit-level=high` threshold. Both are pre-existing on `main`; this branch changes no dependency files.

## Dependencies

None added. The feed is built with template strings and a small escape helper rather than a feed library, which keeps `knip` quiet and avoids a dependency for ~46 lines of output. If you'd rather have a library do it, say so and I'll swap it.

Generated by Claude Opus 5 (review), Kimi K3 (brief, implementation, verification)
