### PR TITLE
ci: push the release commit as a GitHub App, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yaml
+++ b/.github/workflows/deploy-cloudflare-pages.yaml
@@ -19,12 +19,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # main is protected by a ruleset, and GITHUB_TOKEN cannot be given a bypass:
+      # GitHub Actions is not an org-installed app, so it is rejected as a bypass
+      # actor ("must be part of the ruleset source or owner organization").
+      # This app exists solely so the release commit can push through the rule.
+      #
+      # It is deliberately NOT the same app the CTO and CMO runs use. Their token
+      # would then bypass the gate too, which is the whole thing the gate prevents.
+      # This key lives only in pip-web's secrets and nothing else reads it.
+      - name: Mint the release token
+        id: release_app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           # Full history + tags so the release notes can diff against the last
           # release, and so we can push the bump commit back to main.
           fetch-depth: 0
+          # Persist the app credential, so the later `git push` carries the
+          # bypass. Without this the push goes out as GITHUB_TOKEN and the
+          # ruleset rejects it, after the deploy has already gone live.
+          token: ${{ steps.release_app.outputs.token }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -87,7 +106,10 @@ jobs:
           if echo "$subjects" | grep -qi '#major'; then level=major; fi
           pnpm version "$level" --no-git-tag-version >/dev/null
           version=$(node -p "require('./package.json').version")
-          # [skip ci] is belt-and-braces; GITHUB_TOKEN pushes don't retrigger anyway.
+          # [skip ci] IS LOAD-BEARING NOW. It used to be belt-and-braces, because a
+          # GITHUB_TOKEN push cannot retrigger a workflow. This commit is pushed with
+          # a GitHub App token, and App pushes DO retrigger: without the marker this
+          # deploy re-runs itself on its own release commit, forever. Do not remove it.
           git commit -am "chore: release v$version [skip ci]"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Releasing v$version (bump: $level)"
@@ -120,7 +142,8 @@ jobs:
       - name: Tag and publish GitHub Release
         if: github.event_name == 'push'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The app token, not GITHUB_TOKEN: this push has to clear the ruleset.
+          GITHUB_TOKEN: ${{ steps.release_app.outputs.token }}
         run: |
           tag="v${{ steps.release.outputs.version }}"
           git tag "$tag"


### PR DESCRIPTION
Prep for protecting `main` with a ruleset. **Do not merge until the secrets below exist**, or the first step fails and nothing deploys.

## Why

The release step pushes a version-bump commit straight to `main` (`git push origin HEAD:main`). Once a ruleset requires a PR, that push needs a bypass, and `GITHUB_TOKEN` cannot be given one. The API rejects it:

```
Actor GitHub Actions integration must be part of the ruleset source or owner organization
```

GitHub Actions is not an org-installed app, so it is not a valid bypass actor. The push has to come from an identity that is.

## What changed

- A new first step mints a token from a dedicated **`pip-release`** GitHub App.
- `actions/checkout` persists that credential, so the later `git push` carries the bypass.
- The tag/release step uses the same token instead of `GITHUB_TOKEN`.

**`pip-release` is deliberately a separate app from the `pip-bot` the CTO and CMO scheduled runs use.** If they shared one, those runs would hold a token that bypasses the gate, which defeats the point. The `pip-release` key lives only in this repo's secrets and nothing else reads it.

## The hazard this introduces

`[skip ci]` on the release commit was previously belt-and-braces, because a `GITHUB_TOKEN` push cannot retrigger a workflow. **App pushes can.** Without that marker this workflow re-runs itself on its own release commit, forever. The comment now says so in capitals. Do not remove it.

## Before merging

Create the `pip-release` app (org settings -> Developer settings -> GitHub Apps -> New), permissions **Contents: Read and write**, install on `pip-web` only, then:

```bash
gh secret set RELEASE_APP_ID          --repo playpip/pip-web --body "<app id>"
gh secret set RELEASE_APP_PRIVATE_KEY --repo playpip/pip-web < ~/Downloads/pip-release.*.private-key.pem
```

## What the gate covered

`gate` runs the full `test:all` mirror on this PR. **That proves nothing about this change**, which only executes on a push to `main`. The real verification is the first deploy after merge: check that the release commit lands on `main` and the tag and GitHub Release appear. Merge this while you have a minute to watch it, not last thing at night.

Apply the ruleset only after that deploy is confirmed green, so the gate goes up over a push path already known to work.
