### PR TITLE
Let a returning player sign in from onboarding

### DIFF
--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -3,8 +3,10 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { AvatarEditor } from '@/components/profile/AvatarEditor'
+import { AccountDialog } from '@/components/settings/AccountDialog'
 import { AVATAR_BG_SWATCHES, freshSeed, type AvatarSpec } from '@/lib/avatar'
 import { useProfile } from '@/store/profile'
+import { useSync } from '@/store/sync'
 import { sound } from '@/lib/sound'
 
 export function Onboarding({ onCreated }: { onCreated?: () => void }) {
@@ -14,6 +16,9 @@ export function Onboarding({ onCreated }: { onCreated?: () => void }) {
     backgroundColor: AVATAR_BG_SWATCHES[1],
   }))
   const [name, setName] = useState('')
+  const [signInOpen, setSignInOpen] = useState(false)
+  // Sync unconfigured means there are no accounts in this build to return to.
+  const hasAccounts = useSync((s) => s.status !== 'off')
 
   const enter = () => {
     if (!name.trim()) return
@@ -54,6 +59,32 @@ export function Onboarding({ onCreated }: { onCreated?: () => void }) {
         >
           Enter
         </button>
+
+        {/* The way back for someone who already has an account.
+            Without this it was a dead end: onboarding has no AppBar, so no
+            Settings, so no sign-in — a returning player on a new device had to
+            invent a name they didn't want, land in the lobby and go looking.
+            Signing in from here fills the profile in for them instead
+            (sync#syncNow restores outright when the device is pristine).
+
+            It is a text link under Enter, not a second button beside it,
+            because making a player is what this screen is for. It doubles as
+            the only mention a first-timer needs: the sentence tells them
+            accounts exist without asking them for one. */}
+        {hasAccounts && (
+          <>
+            <button
+              onClick={() => {
+                sound.play('tap')
+                setSignInOpen(true)
+              }}
+              className="mt-4 flex min-h-11 w-full items-center justify-center text-xs text-muted-foreground/70 underline-offset-2 transition hover:text-foreground hover:underline"
+            >
+              Already have an account? Sign in
+            </button>
+            <AccountDialog open={signInOpen} mode="signin" onOpenChange={setSignInOpen} />
+          </>
+        )}
       </motion.div>
     </div>
   )


### PR DESCRIPTION
Follow-on to the account-discoverability work. Will's ask: surface the account on the player-creation screen too, so new users know it's possible straight away.

## The thing I found while looking

Onboarding renders with **no AppBar** — so no gear icon, no Settings, no `AccountDialog`. For someone who **already has an account** and arrives on a new device (or after clearing site data), sign-in is currently unreachable. Their only route is to invent a name they didn't want, create a throwaway profile, land in the lobby, and go hunting.

So this is less a nudge than a missing exit.

## What's here

One text link under **Enter**: *"Already have an account? Sign in"*, opening the existing `AccountDialog` in `signin` mode. Hidden entirely when sync isn't configured.

It does both jobs at once — it gives a returning player their door, and it tells a first-timer that accounts exist without asking them for one.

## Verified, not assumed

Signing in from this screen lands you in the lobby rather than stranding you here. Both paths carry `created` through:

- **Account has progress** → `syncNow` hits the pristine-local branch and restores the row outright (`store/sync.ts:277`). The comment there already anticipates exactly this case.
- **Account is itself pristine** (signed up, played nothing) → falls to `mergeProfiles`, where `created: local.created || remote.created` (`lib/sync/merge.ts:74`) — "onboarding is one-way".

## What I deliberately didn't add

**No "create an account" on this screen**, for three reasons in descending order:

1. The account is a copy *of* a player, so there has to be a player first. Signing up here would upload an empty profile and make the first thing your account remembers be nothing.
2. `profile-created` is the healthiest number we have. This is the one screen where a competing call to action could actually cost something.
3. It would contradict "No account needed" at the exact moment we make the claim.

Creating one is one tap away at the foot of Edit player, immediately after this.

## Gate

`pnpm test:all` clean (174 tests), `pnpm build` clean, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
