### PR TITLE
ci: forward a maintainer mention on a PR to the internal automation

### DIFF
--- a/.github/workflows/forward-mention.yaml
+++ b/.github/workflows/forward-mention.yaml
@@ -1,0 +1,135 @@
+name: Forward a maintainer mention
+
+# Lets a maintainer summon the automation from inside a PR review, instead of having to go
+# and open a ticket on an internal tracker to ask for a change.
+#
+# This workflow deliberately does no work of its own. It reads who commented, decides which
+# internal lane the request belongs to, and triggers that lane. Three reasons it is split
+# this way rather than just running the job here:
+#
+#   1. This repo is public, and so are its Actions logs. The lane that does the work prints
+#      its full reasoning to the log, which is fine in a private repo and not fine here.
+#   2. The credentials the work needs would otherwise have to be stored on a public repo.
+#      Nothing sensitive is added here: the token below is the same app that already opens
+#      the PRs, and it is used only to add a reaction and to trigger the lane.
+#   3. Keeping the trigger tiny means the part that can be started from a comment box has
+#      almost no surface area.
+#
+# Author gate, and it is load-bearing: anyone in the world can comment on a public PR, and
+# a run started from a comment executes with this repo's secrets. Without the check below,
+# a stranger could start arbitrary work by typing a magic word. Do not relax it.
+
+on:
+  issue_comment:
+    # `edited` is the re-run handle. A re-run from the Actions tab is pinned to the workflow
+    # file as it was when the run started, so it can never pick up a fix, and deleting and
+    # reposting a comment loses its attachments. Editing fires a fresh event against the
+    # default branch's current file, with the same comment intact.
+    types: [created, edited]
+  # Inline comments on the diff. Without this, a review comment asking for a change looks
+  # exactly like one that works and silently does nothing, which is the worst failure mode.
+  pull_request_review_comment:
+    types: [created, edited]
+  # The summary box at the top of a submitted review.
+  pull_request_review:
+    types: [submitted, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  forward:
+    if: >-
+      github.actor == 'will-lamerton' &&
+      (
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request != null &&
+         (contains(github.event.comment.body, '@pip-eng') ||
+          contains(github.event.comment.body, '@pip-copy'))) ||
+        (github.event_name == 'pull_request_review_comment' &&
+         (contains(github.event.comment.body, '@pip-eng') ||
+          contains(github.event.comment.body, '@pip-copy'))) ||
+        (github.event_name == 'pull_request_review' &&
+         (contains(github.event.review.body, '@pip-eng') ||
+          contains(github.event.review.body, '@pip-copy')))
+      )
+    # Per PR. A single shared group holds only one waiting run, so a third event silently
+    # cancels the queued one - which is what happens when several review comments are left
+    # in a row. Keyed per PR, different PRs never contend.
+    concurrency:
+      group: forward-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Mint the bot token
+        id: bot
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          owner: playpip
+          repositories: |
+            pip-web
+            technology
+            marketing
+
+      # Every value below arrives as an env var rather than being interpolated into the
+      # script. A comment body is attacker-controlled text on a public repo, and pasting it
+      # into a shell line is how that text becomes a command.
+      - name: Hand it to the right lane
+        env:
+          GH_TOKEN: ${{ steps.bot.outputs.token }}
+          EVENT: ${{ github.event_name }}
+          BODY: ${{ github.event.comment.body || github.event.review.body }}
+          PR: ${{ github.event.issue.number || github.event.pull_request.number }}
+          CID: ${{ github.event.comment.id || github.event.review.id }}
+          URL: ${{ github.event.comment.html_url || github.event.review.html_url }}
+        run: |
+          set -euo pipefail
+
+          case "$EVENT" in
+            pull_request_review_comment) KIND=review_comment ;;
+            pull_request_review)         KIND=review ;;
+            *)                           KIND=pr_comment ;;
+          esac
+
+          # Default to the engineering lane: this is a code repo and that is the common case.
+          case "$BODY" in
+            *@pip-copy*) TARGET=marketing ;;
+            *)           TARGET=technology ;;
+          esac
+
+          # Acknowledge, so there is a signal between the comment and the reply some minutes
+          # later. A submitted review has no reactions endpoint, so it gets no eyes.
+          case "$KIND" in
+            review_comment) REACT="pulls/comments/$CID" ;;
+            pr_comment)     REACT="issues/comments/$CID" ;;
+            *)              REACT="" ;;
+          esac
+          if [ -n "$REACT" ]; then
+            gh api --method POST "repos/${{ github.repository }}/$REACT/reactions" \
+              -f content=eyes --silent
+          fi
+
+          # Built with jq rather than string-concatenated, so a comment body that contains
+          # quotes or braces cannot reshape the payload.
+          jq -n --arg pr "$PR" --arg kind "$KIND" --arg cid "$CID" --arg url "$URL" \
+            '{event_type: "pr-mention",
+              client_payload: {pr: $pr, kind: $kind, comment_id: $cid, url: $url}}' \
+          | gh api "repos/playpip/$TARGET/dispatches" --input -
+
+          echo "forwarded PR #$PR ($KIND) to playpip/$TARGET" >> "$GITHUB_STEP_SUMMARY"
+
+      # Without this, a failed hand-off is invisible: the comment gets its eyes and then
+      # nothing ever arrives. The likely causes are a stale app key in this repo's secrets or
+      # the internal lane not existing on its default branch yet.
+      - name: Say so if the hand-off failed
+        if: ${{ failure() || cancelled() }}
+        env:
+          GH_TOKEN: ${{ steps.bot.outputs.token }}
+          PR: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR" --repo ${{ github.repository }} \
+            --body "That request was not picked up, so no reply is coming. [Run ${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) has the error."


### PR DESCRIPTION
Adds one workflow so a maintainer can request a change from inside a PR review, rather than filing a ticket elsewhere and pointing at the PR.

### What it does

Comment `@pip-eng ...` (code) or `@pip-copy ...` (copy) on a PR here and the automation picks it up, amends the branch, and replies in the same thread. It works in the conversation tab, in a review summary, and **inline on the diff**, which is the useful one: an inline comment carries the file and line, so there is nothing to guess.

### What it deliberately does not do

**No work happens in this repo.** The job matches the trigger, adds a 👀, and fires a `repository_dispatch` at the private repo that handles it. That split is the point:

- **Actions logs here are public.** The job that does the work prints its full reasoning to the log. That is fine in a private repo and not fine in this one.
- **No new sensitive secrets.** It needs `BOT_APP_ID` / `BOT_APP_PRIVATE_KEY`, which is the same app that already opens every PR on this repo. No Claude token, no other app keys.
- **`repository_dispatch`, not a cross-repo `workflow_dispatch`.** The latter needs `actions: write`, which this app does not have; the former needs `contents: write`, which it does. One less permission grant.

### Security notes

- **Hard author gate.** Anyone in the world can comment on a public PR, and a run started from a comment executes with this repo's secrets. Only one login passes. This is not a formality.
- The comment body reaches the shell only as an env var, and the dispatch payload is built with `jq -n`, so a body containing quotes or braces cannot reshape either.
- `permissions: contents: read`, and a 5 minute timeout.

### Gate

Nothing to run: this touches no application code, no dependencies and no build. `ci.yaml` runs on `pull_request` and will report as usual.

**Inert until `BOT_APP_ID` and `BOT_APP_PRIVATE_KEY` are set** on this repo. Until then the trigger matches and the dispatch step fails, which posts a note on the PR rather than failing silently.
