### PR TITLE
fix(ci): anchor the release range on the last tag, not github.event.before

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yaml
+++ b/.github/workflows/deploy-cloudflare-pages.yaml
@@ -89,18 +89,42 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           level=patch
-          # Read every subject in the pushed range, not just the tip. A feature
-          # is rarely the last commit on a branch: sync's #minor was thirteen
-          # commits down when it landed and shipped as a patch. See technology#18.
+          # Read every subject since the LAST RELEASE TAG, not just the tip. A
+          # feature is rarely the last commit on a branch: sync's #minor was
+          # thirteen commits down when it landed and shipped as a patch
+          # (technology#18).
+          #
+          # The anchor is the tag rather than github.event.before because this
+          # workflow's concurrency group cancels in-progress runs. When several
+          # merges land inside a minute, every run but the last dies seconds in,
+          # and `before..sha` for the survivor covers ONLY the last merge — every
+          # #minor in a cancelled run's range is never read. Nothing fails and
+          # nothing warns; the site is right and the number is wrong. It ate a
+          # #minor twice (shipped as v1.8.5 and v1.8.11; technology#41).
+          #
+          # A cancelled run leaves no tag behind, so anchoring here makes the
+          # next surviving run's range automatically cover everything the
+          # cancelled ones would have. It is also the range `--generate-notes`
+          # already uses below, so the bump and the notes can no longer disagree.
           before='${{ github.event.before }}'
-          if git rev-parse --quiet --verify "$before^{commit}" >/dev/null 2>&1; then
-            subjects=$(git log --pretty=%s "$before..${{ github.sha }}")
+          last_tag=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null || true)
+          if [ -n "$last_tag" ]; then
+            range="$last_tag..${{ github.sha }}"
+          elif git rev-parse --quiet --verify "$before^{commit}" >/dev/null 2>&1; then
+            # No release tag reachable yet (first release, or tags unfetched).
+            # The pushed range is the next best anchor.
+            range="$before..${{ github.sha }}"
+          else
+            range=''
+          fi
+          if [ -n "$range" ]; then
+            subjects=$(git log --pretty=%s "$range")
           else
             # First push to the branch or a force-push: no usable range, so the
             # tip is the honest answer rather than an error.
             subjects=$(git log -1 --pretty=%s)
           fi
-          echo "Subjects in range:"
+          echo "Subjects in range (${range:-tip only}):"
           echo "$subjects"
           if echo "$subjects" | grep -qi '#minor'; then level=minor; fi
           if echo "$subjects" | grep -qi '#major'; then level=major; fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -127,6 +127,11 @@ successful deploy:
 - **Version** auto-bumps — **patch by default**; put `#minor` or `#major` in the
   commit **subject** (first line only — the body is ignored, so prose mentioning
   the tokens can't trigger a bump) to bump harder (`#major` wins if both appear).
+- **Every subject since the last release tag is read**, not just the tip and not
+  just the pushed range. The workflow's concurrency group cancels in-progress
+  runs, so a burst of merges leaves only the last run alive — anchoring on the
+  tag means the surviving run still picks up the markers from the merges whose
+  runs were killed. It is the same range the release notes are generated from.
 - The bump is **committed before the build**, so the deployed PWA reports the new
   version and its build id is the release commit.
 - Then it **tags `vX.Y.Z`, pushes it, and publishes a GitHub Release** with
@@ -134,14 +139,18 @@ successful deploy:
 
 Notes:
 
-- No infinite loop: the bump commit is pushed with the default `GITHUB_TOKEN`
-  (which doesn't retrigger workflows) and carries `[skip ci]` as belt-and-braces.
-  The workflow declares `permissions: contents: write` and checks out with
-  `fetch-depth: 0` (needed to push and to diff release notes).
+- No infinite loop, but **`[skip ci]` on the release commit is load-bearing**: the
+  commit is pushed with a GitHub App token (it has to clear the ruleset on `main`),
+  and App pushes _do_ retrigger workflows. Without the marker the deploy re-runs
+  itself on its own release commit, forever. The workflow declares
+  `permissions: contents: write` and checks out with `fetch-depth: 0` (needed to
+  push, to read the last tag, and to diff release notes).
 - A manual `workflow_dispatch` run **redeploys the current version** — no bump, no
   release (the release steps are gated to `push` events).
-- This pushes **directly to `main`** — if you add branch protection that blocks
-  everyone, exempt the `github-actions` bot or move to a Release-PR model.
+- This pushes **directly to `main`**, which a ruleset otherwise blocks. `GITHUB_TOKEN`
+  cannot be a bypass actor, so the release commit is pushed as a dedicated GitHub App
+  whose credentials live only in this repo's secrets. It is deliberately not the app
+  any other automation uses — sharing it would hand that automation a bypass too.
 
 ### Versioning & cache-busting
 


### PR DESCRIPTION
Fixes playpip/technology#41.

## What was wrong

The concurrency group is `deploy-pages` with `cancel-in-progress: true`. When several merges land inside a minute, every run but the last is cancelled seconds in. The survivor computed its range as `github.event.before..github.sha`, which covers **only the last merge** — every `#minor`/`#major` in a cancelled run's range was never read. Nothing failed and nothing warned; the site was right and only the number was wrong. It ate a bump twice (shipped as v1.8.5 and v1.8.11).

## The change

Anchor the range on the last release tag. A cancelled run leaves no tag behind, so the next surviving run's range automatically covers everything the cancelled ones would have. It is also the range `--generate-notes` already uses, so the bump and the notes can no longer disagree.

Two fallbacks, so the worst case is today's behaviour rather than an error:

1. last release tag → `tag..sha`
2. no tag reachable (first release, tags unfetched) → `before..sha`
3. all-zeros `before` (force-push / first push) → tip only

## Verification

Replayed the incident against a scratch repo — tag `v1.8.4`, then `feat(learn): guide 2 #minor`, two more commits, `before` set to the tip's parent the way a surviving run sees it:

| | range | level |
|---|---|---|
| old | `<before>..<sha>` | `patch` ← the eaten bump |
| new | `v1.8.4..<sha>` | `minor` ← recovered |

Also exercised: `#major` beating `#minor` in the same range, the tag commit itself correctly excluded from the range, and both fallbacks (no tags → pushed range; no tags + all-zeros `before` → tip only).

`pnpm test:all` green. The YAML parses and the step's embedded shell passes `bash -n`. No app code changed, so the gate only says "nothing else broke".

**Not verified, and cannot be:** the real thing. `workflow_dispatch` can't exercise the bump step — it's gated to `push`. The first real test is the merge after this lands. Merging this PR alone cuts a patch, which is correct for it.

## Also in here

Two stale notes in `docs/development.md`: it still said the release commit is pushed with `GITHUB_TOKEN` and that `[skip ci]` is belt-and-braces. That is backwards now — the commit is pushed with an App token and App pushes *do* retrigger workflows, so removing the marker would put the deploy in a loop.

Not touching v1.8.5 or v1.8.11, per the call in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
