### PR TITLE
Add play-style read tests

### DIFF
--- a/tests/playStyle.test.ts
+++ b/tests/playStyle.test.ts
@@ -1,11 +1,8 @@
 import test from 'ava'
-import { derivePlayStyle, STYLE_MIN_HANDS, type StyleKey } from '@/lib/playStyle'
+import { derivePlayStyle, STYLE_MIN_HANDS } from '@/lib/playStyle'
 import { emptySeatStats, type SeatStats } from '@/lib/reads'
 
 const stats = (over: Partial<SeatStats> = {}): SeatStats => ({ ...emptySeatStats(), ...over })
-
-const publicKeys: StyleKey[] = ['shark', 'maniac', 'rock', 'station']
-const publicNames = ['The Shark', 'The Maniac', 'The Rock', 'The Station']
 
 const archetypeCases = [
   {
@@ -93,8 +90,20 @@ test('derivePlayStyle returns zero for each empty rate denominator', (t) => {
 })
 
 const readinessCases = [
-  { label: 'below the minimum sample', hands: STYLE_MIN_HANDS - 1, ready: false },
-  { label: 'at the minimum sample', hands: STYLE_MIN_HANDS, ready: true },
+  {
+    label: 'below the minimum sample',
+    hands: STYLE_MIN_HANDS - 1,
+    ready: false,
+    key: 'maniac' as const,
+    name: 'The Maniac',
+  },
+  {
+    label: 'at the minimum sample',
+    hands: STYLE_MIN_HANDS,
+    ready: true,
+    key: 'maniac' as const,
+    name: 'The Maniac',
+  },
 ]
 
 test('derivePlayStyle gates readiness without losing a valid classification', (t) => {
@@ -109,7 +118,7 @@ test('derivePlayStyle gates readiness without losing a valid classification', (t
     )
 
     t.is(style.ready, sample.ready, sample.label)
-    t.true(publicKeys.includes(style.key), `${sample.label} key`)
-    t.true(publicNames.includes(style.name), `${sample.label} name`)
+    t.is(style.key, sample.key, `${sample.label} key`)
+    t.is(style.name, sample.name, `${sample.label} name`)
   }
 })

--- a/tests/playStyle.test.ts
+++ b/tests/playStyle.test.ts
@@ -1,0 +1,115 @@
+import test from 'ava'
+import { derivePlayStyle, STYLE_MIN_HANDS, type StyleKey } from '@/lib/playStyle'
+import { emptySeatStats, type SeatStats } from '@/lib/reads'
+
+const stats = (over: Partial<SeatStats> = {}): SeatStats => ({ ...emptySeatStats(), ...over })
+
+const publicKeys: StyleKey[] = ['shark', 'maniac', 'rock', 'station']
+const publicNames = ['The Shark', 'The Maniac', 'The Rock', 'The Station']
+
+const archetypeCases = [
+  {
+    label: 'tight and passive',
+    over: { handsDealt: 100, vpipHands: 41, raises: 1, calls: 2 },
+    key: 'rock' as const,
+    name: 'The Rock',
+    looseness: 41 / 100,
+    aggression: 1 / 3,
+  },
+  {
+    label: 'loose at the 42 percent boundary and passive',
+    over: { handsDealt: 100, vpipHands: 42, raises: 1, calls: 2 },
+    key: 'station' as const,
+    name: 'The Station',
+    looseness: 42 / 100,
+    aggression: 1 / 3,
+  },
+  {
+    label: 'tight and aggressive at the one-half boundary',
+    over: { handsDealt: 100, vpipHands: 41, raises: 1, calls: 1 },
+    key: 'shark' as const,
+    name: 'The Shark',
+    looseness: 41 / 100,
+    aggression: 1 / 2,
+  },
+  {
+    label: 'loose and aggressive at both boundaries',
+    over: { handsDealt: 100, vpipHands: 42, raises: 1, calls: 1 },
+    key: 'maniac' as const,
+    name: 'The Maniac',
+    looseness: 42 / 100,
+    aggression: 1 / 2,
+  },
+  {
+    label: 'loose and aggressive above both boundaries',
+    over: { handsDealt: 100, vpipHands: 43, raises: 2, calls: 1 },
+    key: 'maniac' as const,
+    name: 'The Maniac',
+    looseness: 43 / 100,
+    aggression: 2 / 3,
+  },
+]
+
+test('derivePlayStyle names all four public archetypes at their observable boundaries', (t) => {
+  for (const sample of archetypeCases) {
+    const style = derivePlayStyle(stats(sample.over))
+
+    t.is(style.key, sample.key, sample.label)
+    t.is(style.name, sample.name, `${sample.label} name`)
+    t.is(style.looseness, sample.looseness, `${sample.label} looseness`)
+    t.is(style.aggression, sample.aggression, `${sample.label} aggression`)
+  }
+})
+
+type RateAxis = 'looseness' | 'aggression' | 'foldToBet'
+
+const zeroDenominatorCases: Array<{
+  label: string
+  over: Partial<SeatStats>
+  axis: RateAxis
+}> = [
+  {
+    label: 'no hands dealt',
+    over: { handsDealt: 0, vpipHands: 0, raises: 2, calls: 1, betsFaced: 4, foldsToBet: 1 },
+    axis: 'looseness',
+  },
+  {
+    label: 'no raises or calls',
+    over: { handsDealt: 10, vpipHands: 5, raises: 0, calls: 0, betsFaced: 4, foldsToBet: 1 },
+    axis: 'aggression',
+  },
+  {
+    label: 'no bets faced',
+    over: { handsDealt: 10, vpipHands: 5, raises: 1, calls: 1, betsFaced: 0, foldsToBet: 0 },
+    axis: 'foldToBet',
+  },
+]
+
+test('derivePlayStyle returns zero for each empty rate denominator', (t) => {
+  for (const sample of zeroDenominatorCases) {
+    const style = derivePlayStyle(stats(sample.over))
+    t.is(style[sample.axis], 0, sample.label)
+  }
+})
+
+const readinessCases = [
+  { label: 'below the minimum sample', hands: STYLE_MIN_HANDS - 1, ready: false },
+  { label: 'at the minimum sample', hands: STYLE_MIN_HANDS, ready: true },
+]
+
+test('derivePlayStyle gates readiness without losing a valid classification', (t) => {
+  for (const sample of readinessCases) {
+    const style = derivePlayStyle(
+      stats({
+        handsDealt: sample.hands,
+        vpipHands: Math.floor(sample.hands / 2),
+        raises: 1,
+        calls: 1,
+      }),
+    )
+
+    t.is(style.ready, sample.ready, sample.label)
+    t.true(publicKeys.includes(style.key), `${sample.label} key`)
+    t.true(publicNames.includes(style.name), `${sample.label} name`)
+  }
+})


### PR DESCRIPTION
**Summary**
Adds focused AVA coverage for `derivePlayStyle()` so its public classifications, split boundaries, zero-rate fallbacks, and readiness threshold are regression-tested.

**Related Issues and Pull Requests**
Refs #54

**Changes**
- Added table-driven coverage for all four exact public play-style key/name pairs, including behavior at the looseness and aggression split boundaries.
- Added assertions that empty hands, actions, and bets-faced denominators return numerical zero values.
- Added exact `maniac` / `The Maniac` classification checks below and at `STYLE_MIN_HANDS`, alongside the false/true readiness checks.

**Testing**
- Focused local checks passed: `pnpm exec ava tests/playStyle.test.ts` (3 tests), `pnpm exec biome check tests/playStyle.test.ts`, `pnpm exec tsc --noEmit --pretty false`, and `git diff --check`.
- Full runner CI [32811078861](https://github.com/Nitjsefnie-OSC/pip-web/actions/runs/32811078861) passed its single job with 475 AVA tests; the log names checked-out SHA `7d73e94f965ef019b85eccf8c536e18e1cdab431`.
- Targeted readiness-classification mutation [32811263880](https://github.com/Nitjsefnie-OSC/pip-web/actions/runs/32811263880) produced the intended RED result at `tests/playStyle.test.ts:122`: actual `The Rock`, expected `The Maniac`.

**Footer**
Generated by GPT-5.6 Luna (implementation, testing), GPT-5.6 Sol (brief, review, verification)
